### PR TITLE
fix: improve resource fallback diagnostics

### DIFF
--- a/src/x_ite/InputOutput/FileLoader.js
+++ b/src/x_ite/InputOutput/FileLoader.js
@@ -13,6 +13,12 @@ const foreignMimeType = new Set ([
 
 const _cache = Symbol .for ("X_ITE.cache");
 
+// Keep diagnostics readable when a candidate is a long data URL.
+function truncate (string, length = 120)
+{
+   return string .length > length ? `${string .substring (0, length)}…` : string;
+}
+
 function FileLoader (node, { cacheScene = false, dataAsString = true } = { })
 {
    X3DObject .call (this);
@@ -26,6 +32,8 @@ function FileLoader (node, { cacheScene = false, dataAsString = true } = { })
    this .url              = [ ];
    this .fileURL          = new URL (this .getBaseURL ());
    this .controller       = new AbortController ();
+   this .candidateURL     = "";
+   this .attempts         = [ ];
 }
 
 Object .assign (FileLoader,
@@ -167,6 +175,8 @@ Object .assign (Object .setPrototypeOf (FileLoader .prototype, X3DObject .protot
       this .url      = url .slice ();
       this .callback = callback;
 
+      this .attempts .length = 0;
+
       if (url .length === 0)
          return this .loadDocumentError ();
 
@@ -175,8 +185,10 @@ Object .assign (Object .setPrototypeOf (FileLoader .prototype, X3DObject .protot
    },
    async loadDocumentAsync (url)
    {
+      this .candidateURL = url;
+
       if (!url .length)
-         return this .loadDocumentError ();
+         return this .loadDocumentError (Error ("Empty URL."));
 
       // Script:
       {
@@ -346,12 +358,33 @@ Object .assign (Object .setPrototypeOf (FileLoader .prototype, X3DObject .protot
       if (!error)
          return;
 
-      const typeName = this .node instanceof X3DWorld ? "" : ` for ${this .node .getTypeName ()}`;
+      // An empty candidate never reached URL resolution, so this .fileURL still
+      // refers to the previous candidate and must not be reported as the subject.
 
-      if (this .fileURL .protocol === "data:")
-         console .error (`Couldn't load data URL${typeName}.`, error);
-      else
-         console .error (`Couldn't load URL '${$.try (() => decodeURI (this .fileURL)) ?? this .fileURL}'${typeName}.`, error);
+      const
+         typeName = this .node instanceof X3DWorld ? "" : ` for ${this .node .getTypeName ()}`,
+         empty    = !this .candidateURL .length,
+         dataURL  = this .fileURL .protocol === "data:",
+         resolved = empty || dataURL ? "" : `${$.try (() => decodeURI (this .fileURL)) ?? this .fileURL}`,
+         subject  = empty ? "empty URL" : dataURL ? "data URL" : `URL '${resolved}'`;
+
+      this .attempts .push ({ url: this .candidateURL, resolved, error });
+
+      // A url field is a fallback list, so a failed candidate is not yet a failure of
+      // the resource: a later candidate may still succeed. Report the resource as
+      // failed only once every candidate has been tried.
+
+      if (this .url .length)
+         return console .warn (`Couldn't load ${subject}${typeName}, trying next of ${this .attempts .length + this .url .length} URLs.`, error);
+
+      if (this .attempts .length === 1)
+         return console .error (`Couldn't load ${subject}${typeName}.`, error);
+
+      console .error (`Couldn't load any of the ${this .attempts .length} URLs${typeName}, tried in this order:\n`
+         + this .attempts
+            .map (({ url, resolved, error }, i) =>
+               `  ${i + 1}. '${truncate (url)}'${resolved && resolved !== url ? ` → ${truncate (resolved)}` : ""}: ${error ?.message ?? error}`)
+            .join ("\n"));
    },
 });
 

--- a/src/x_ite/InputOutput/FileLoader.js
+++ b/src/x_ite/InputOutput/FileLoader.js
@@ -389,7 +389,7 @@ Object .assign (Object .setPrototypeOf (FileLoader .prototype, X3DObject .protot
       // failed only once every candidate has been tried.
 
       if (this .url .length)
-         return console .warn (`Couldn't load ${subject}${typeName}, trying next of ${this .attempts .length + this .url .length} URLs.`, error);
+         return console .warn (`Couldn't load ${subject}${typeName}, trying URL ${this .attempts .length + 1} of ${this .attempts .length + this .url .length}.`, error);
 
       if (this .attempts .length === 1)
          return console .error (`Couldn't load ${subject}${typeName}.`, error);

--- a/src/x_ite/InputOutput/FileLoader.js
+++ b/src/x_ite/InputOutput/FileLoader.js
@@ -19,6 +19,12 @@ function truncate (string, length = 120)
    return string .length > length ? `${string .substring (0, length)}…` : string;
 }
 
+// Not every thrown value is an Error, so don't summarize one as [object Object].
+function describe (error)
+{
+   return error ?.message ?? (typeof error === "object" ? $.try (() => JSON .stringify (error)) : null) ?? String (error);
+}
+
 function FileLoader (node, { cacheScene = false, dataAsString = true } = { })
 {
    X3DObject .call (this);
@@ -33,6 +39,7 @@ function FileLoader (node, { cacheScene = false, dataAsString = true } = { })
    this .fileURL          = new URL (this .getBaseURL ());
    this .controller       = new AbortController ();
    this .candidateURL     = "";
+   this .resolvedURL      = null;
    this .attempts         = [ ];
 }
 
@@ -185,7 +192,12 @@ Object .assign (Object .setPrototypeOf (FileLoader .prototype, X3DObject .protot
    },
    async loadDocumentAsync (url)
    {
+      // Not every candidate reaches URL resolution, so resolvedURL stays null until it
+      // does. Diagnostics must not attribute the previous candidate's resolved URL to
+      // this one.
+
       this .candidateURL = url;
+      this .resolvedURL  = null;
 
       if (!url .length)
          return this .loadDocumentError (Error ("Empty URL."));
@@ -198,7 +210,8 @@ Object .assign (Object .setPrototypeOf (FileLoader .prototype, X3DObject .protot
             return await this .callback (url .substring (result [0] .length));
       }
 
-      this .fileURL = new URL (url, this .getBaseURL ());
+      this .fileURL     = new URL (url, this .getBaseURL ());
+      this .resolvedURL = this .fileURL;
 
       // Handle data URLs that are not base64 decoded here:
       if (this .dataAsString)
@@ -358,15 +371,16 @@ Object .assign (Object .setPrototypeOf (FileLoader .prototype, X3DObject .protot
       if (!error)
          return;
 
-      // An empty candidate never reached URL resolution, so this .fileURL still
-      // refers to the previous candidate and must not be reported as the subject.
+      // Candidates that are evaluated rather than fetched — an empty string, or a
+      // script URL — have no resolved URL, and are reported by their authored value.
 
       const
          typeName = this .node instanceof X3DWorld ? "" : ` for ${this .node .getTypeName ()}`,
-         empty    = !this .candidateURL .length,
-         dataURL  = this .fileURL .protocol === "data:",
-         resolved = empty || dataURL ? "" : `${$.try (() => decodeURI (this .fileURL)) ?? this .fileURL}`,
-         subject  = empty ? "empty URL" : dataURL ? "data URL" : `URL '${resolved}'`;
+         dataURL  = this .resolvedURL ?.protocol === "data:",
+         resolved = this .resolvedURL && !dataURL ? `${$.try (() => decodeURI (this .resolvedURL)) ?? this .resolvedURL}` : "",
+         subject  = !this .candidateURL .length ? "empty URL"
+            : dataURL ? "data URL"
+            : `URL '${resolved || truncate (this .candidateURL)}'`;
 
       this .attempts .push ({ url: this .candidateURL, resolved, error });
 
@@ -380,11 +394,15 @@ Object .assign (Object .setPrototypeOf (FileLoader .prototype, X3DObject .protot
       if (this .attempts .length === 1)
          return console .error (`Couldn't load ${subject}${typeName}.`, error);
 
+      // Pass the errors themselves along with the summary, so their stacks and context
+      // stay inspectable.
+
       console .error (`Couldn't load any of the ${this .attempts .length} URLs${typeName}, tried in this order:\n`
          + this .attempts
             .map (({ url, resolved, error }, i) =>
-               `  ${i + 1}. '${truncate (url)}'${resolved && resolved !== url ? ` → ${truncate (resolved)}` : ""}: ${error ?.message ?? error}`)
-            .join ("\n"));
+               `  ${i + 1}. '${truncate (url)}'${resolved && resolved !== url ? ` → ${truncate (resolved)}` : ""}: ${describe (error)}`)
+            .join ("\n"),
+         ... this .attempts .map (({ error }) => error));
    },
 });
 


### PR DESCRIPTION
## Problem

A `url` field is a fallback list, so X_ITE tries each entry until one loads. But every failed candidate currently goes to `console.error`, which has two annoying results:

* a resource that loads fine off its second or third URL still prints errors, so the console makes a successful load look broken
* when every candidate fails, you get N separate errors with nothing tying them together, no indication of the order they were tried in, and no single "this resource failed" line

It shows up most with older VRML97 content, where multi-URL fallback lists are common and a lot of the alternates point at hosts that have been gone for years. Working out from the console whether anything actually failed is harder than it should be.

## Change

Reporting only:

* a candidate that fails while others are still to try is now a warning, not an error
* when the list runs out, one error lists all the URLs in the order they were tried, with the resolved URL alongside the authored one where they differ
* an empty string in a url list is now reported as an empty URL. Previously it printed the *previous* candidate's URL, because `this.fileURL` was never updated for it
* values in the aggregate message are cut at 120 characters so a long data URL doesn't flood the console

Load behaviour, URL resolution and fallback order are unchanged, and so are load states. A single-candidate failure is still a single error, and an empty MFString is still silent.

## Testing

`npx eslint src/x_ite/InputOutput/FileLoader.js` is clean, 0 errors and 0 warnings.

I ran the unbundled `src` in headless chromium against small synthetic scenes covering:

* direct successful load (silent)
* one candidate, fails (one error, as before)
* first candidate fails, second succeeds (warning only, node reaches COMPLETE)
* all candidates fail (warnings, then one ordered aggregate error)
* relative URL resolution against baseURL, unchanged
* `Inline`, both fallback success and exhaustion
* `EXTERNPROTO`, both fallback success and exhaustion
* missing PROTO fragment in the first candidate, falls through to the second
* resource that returns HTTP 200 but doesn't parse, falls through correctly
* empty URL candidate, and an all-empty url field
* url field mutated repeatedly between failing and working lists, so the attempt list resets per load rather than accumulating
* two Inlines failing concurrently, each reporting only its own URLs
* long path and long data URI, truncation stays bounded

For what it's worth on the repo test suite: the browser project points at a host on your network, so I can't run it here. I haven't touched anything in `x_ite-tests`, and there's no `dist` rebuild in this PR, just the one source file.